### PR TITLE
Add dedicated contact page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Contact | Sara de Vries - Logistiek Planner</title>
+    <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+    <div class="page-wrapper">
+        <header class="hero hero--compact" id="top">
+            <div class="hero__text">
+                <h1>Neem contact op</h1>
+                <p class="hero__subtitle">Ik hoor graag van je</p>
+                <p class="hero__bio">
+                    Laat een bericht achter via het formulier of kies een directe contactmethode.
+                </p>
+                <div class="hero__contact">
+                    <a href="mailto:sara.devries@email.com">sara.devries@email.com</a>
+                    <span>|</span>
+                    <a href="tel:+31612345678">+31 6 12345678</a>
+                    <span>|</span>
+                    <a href="index.html">Terug naar portfolio</a>
+                </div>
+            </div>
+        </header>
+
+        <main>
+            <section class="section section--contact">
+                <div class="section__header">
+                    <h2>Contactformulier</h2>
+                    <p>Vul je gegevens in en ik neem zo snel mogelijk contact met je op.</p>
+                </div>
+                <form class="contact-form">
+                    <div class="form-group">
+                        <label for="name">Naam</label>
+                        <input type="text" id="name" name="name" placeholder="Je naam" required />
+                    </div>
+                    <div class="form-group">
+                        <label for="email">E-mailadres</label>
+                        <input type="email" id="email" name="email" placeholder="naam@email.com" required />
+                    </div>
+                    <div class="form-group">
+                        <label for="message">Bericht</label>
+                        <textarea id="message" name="message" rows="6" placeholder="Waarmee kan ik je helpen?" required></textarea>
+                    </div>
+                    <button type="submit" class="button">Verstuur bericht</button>
+                </form>
+            </section>
+        </main>
+
+        <footer class="footer">
+            <p>&copy; <span id="year"></span> Sara de Vries. Alle rechten voorbehouden.</p>
+            <a class="back-to-top" href="#top">Terug naar boven &uarr;</a>
+        </footer>
+    </div>
+
+    <script>
+        document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@ doortastendheid te combineren. Met ruim vijf jaar ervaring in de supply chain zo
                     <span>|</span>
                     <a href="tel:+31612345678">+31 6 12345678</a>
                     <span>|</span>
-                    <a href="#contact">Contactformulier</a>
+                    <a href="contact.html">Contactformulier</a>
                 </div>
             </div>
             <div class="hero__image">
@@ -92,27 +92,14 @@ doortastendheid te combineren. Met ruim vijf jaar ervaring in de supply chain zo
                 </div>
             </section>
 
-            <section class="section section--contact" id="contact">
+            <section class="section section--contact-preview">
                 <div class="section__header">
                     <h2>Contact</h2>
-                    <p>Stuur een bericht en ik neem zo snel mogelijk contact met je op.</p>
+                    <p>
+                        Liever direct in contact komen? Gebruik het contactformulier op de
+                        <a href="contact.html">aparte contactpagina</a> om een bericht te sturen.
+                    </p>
                 </div>
-                <!-- Simpel contactformulier zonder backend. Kan met bijv. Formspree worden gekoppeld. -->
-                <form class="contact-form">
-                    <div class="form-group">
-                        <label for="name">Naam</label>
-                        <input type="text" id="name" name="name" placeholder="Je naam" required />
-                    </div>
-                    <div class="form-group">
-                        <label for="email">E-mailadres</label>
-                        <input type="email" id="email" name="email" placeholder="naam@email.com" required />
-                    </div>
-                    <div class="form-group">
-                        <label for="message">Bericht</label>
-                        <textarea id="message" name="message" rows="5" placeholder="Waarmee kan ik je helpen?" required></textarea>
-                    </div>
-                    <button type="submit" class="button">Verstuur bericht</button>
-                </form>
             </section>
         </main>
 

--- a/styles.css
+++ b/styles.css
@@ -56,6 +56,12 @@ a:focus {
     color: var(--color-white);
 }
 
+.hero--compact {
+    grid-template-columns: 1fr;
+    text-align: center;
+    padding: 3.5rem 1.5rem 2.5rem;
+}
+
 .hero__text {
     max-width: 580px;
     margin: 0 auto;


### PR DESCRIPTION
## Summary
- create a standalone `contact.html` page that reuses the existing contactform styling
- update the portfolio landing page to link to the new contact page and introduce a preview section
- add a compact hero variant for the contact page hero layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbbcc31fcc83249304333784c3cc98