### PR TITLE
Add trainings page detailing professional development

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,8 @@ doortastendheid te combineren. Met ruim vijf jaar ervaring in de supply chain zo
                     <span>|</span>
                     <a href="tel:+31612345678">+31 6 12345678</a>
                     <span>|</span>
+                    <a href="trainings.html">Trainingen</a>
+                    <span>|</span>
                     <a href="contact.html">Contactformulier</a>
                 </div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -183,6 +183,79 @@ main {
     background: linear-gradient(160deg, rgba(15, 76, 129, 0.1), rgba(242, 163, 101, 0.2));
 }
 
+.section--trainings-overview .trainings-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.75rem;
+}
+
+.training {
+    background-color: rgba(15, 76, 129, 0.04);
+    border: 1px solid rgba(15, 76, 129, 0.12);
+    border-radius: 18px;
+    padding: 1.75rem;
+    box-shadow: 0 12px 30px rgba(15, 76, 129, 0.08);
+}
+
+.training h3 {
+    font-family: var(--font-heading);
+    margin-top: 0;
+}
+
+.training__meta {
+    display: inline-block;
+    margin-bottom: 0.75rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--color-primary);
+}
+
+.training__highlights {
+    padding-left: 1.2rem;
+    margin: 1rem 0 0;
+    color: var(--color-muted);
+}
+
+.training__highlights li + li {
+    margin-top: 0.4rem;
+}
+
+.section--microlearning .training-timeline {
+    display: grid;
+    gap: 1.25rem;
+}
+
+.timeline-item {
+    display: grid;
+    grid-template-columns: 120px 1fr;
+    gap: 1.25rem;
+    align-items: start;
+    padding: 1.5rem;
+    border-radius: 16px;
+    background: linear-gradient(160deg, rgba(242, 163, 101, 0.16), rgba(15, 76, 129, 0.08));
+    border: 1px solid rgba(15, 76, 129, 0.12);
+}
+
+.timeline-item__date {
+    font-weight: 700;
+    color: var(--color-primary);
+}
+
+.timeline-item__content h3 {
+    margin-top: 0;
+    font-family: var(--font-heading);
+}
+
+.section--cta .section__header {
+    max-width: 560px;
+    margin: 0 auto;
+}
+
+.section--cta .button {
+    margin: 1.5rem auto 0;
+    display: inline-block;
+}
+
 .contact-form {
     display: grid;
     gap: 1.25rem;
@@ -248,6 +321,10 @@ textarea:focus {
 @media (max-width: 600px) {
     .hero {
         padding: 3rem 1.25rem 2.5rem;
+    }
+
+    .timeline-item {
+        grid-template-columns: 1fr;
     }
 
     .hero__image img {

--- a/trainings.html
+++ b/trainings.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Trainingen | Sara de Vries - Logistiek Planner</title>
+    <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+    <div class="page-wrapper">
+        <header class="hero hero--compact" id="top">
+            <div class="hero__text">
+                <h1>Trainingen &amp; Certificeringen</h1>
+                <p class="hero__subtitle">Levenslang leren voor logistieke excellentie</p>
+                <p class="hero__bio">
+                    Een overzicht van opleidingen, certificeringen en microlearnings waarmee ik mijn kennis
+                    up-to-date houd binnen supply chain management.
+                </p>
+                <div class="hero__contact">
+                    <a href="index.html">Terug naar portfolio</a>
+                    <span>|</span>
+                    <a href="contact.html">Contact opnemen</a>
+                </div>
+            </div>
+        </header>
+
+        <main>
+            <section class="section section--trainings-overview">
+                <div class="section__header">
+                    <h2>Strategische opleidingen</h2>
+                    <p>
+                        Verdiepende programma's gericht op procesoptimalisatie, leiderschap en data-gedreven
+                        besluitvorming.
+                    </p>
+                </div>
+                <div class="trainings-grid">
+                    <article class="training">
+                        <h3>Lean Six Sigma Black Belt</h3>
+                        <span class="training__meta">Lean Academy | 2023</span>
+                        <p>
+                            Intensief traject voor het leiden van complexe verbeterprojecten met meetbare
+                            resultaten en duurzame verandering.
+                        </p>
+                        <ul class="training__highlights">
+                            <li>DMAIC-projecten met focus op logistieke stromen</li>
+                            <li>Coaching van teams in continu verbeteren</li>
+                            <li>Gecertificeerd na het behalen van praktijkcase en theorie-examen</li>
+                        </ul>
+                    </article>
+                    <article class="training">
+                        <h3>Advanced Supply Chain Analytics</h3>
+                        <span class="training__meta">TIAS Business School | 2022</span>
+                        <p>
+                            Programma over het inzetten van data science voor forecasting, voorraadbeheer en
+                            scenarioplanning in dynamische ketens.
+                        </p>
+                        <ul class="training__highlights">
+                            <li>Hands-on met Power BI, Python en SQL</li>
+                            <li>Case studies rond demand sensing en S&amp;OP</li>
+                            <li>Toepassing van predictive modellen op real-life data</li>
+                        </ul>
+                    </article>
+                    <article class="training">
+                        <h3>People Leadership in Operations</h3>
+                        <span class="training__meta">Nyenrode Business Universiteit | 2021</span>
+                        <p>
+                            Leiderschapsprogramma gericht op het aansturen van multidisciplinaire teams en het
+                            borgen van change-management trajecten.
+                        </p>
+                        <ul class="training__highlights">
+                            <li>Situational leadership en coachende vaardigheden</li>
+                            <li>Communicatie- en stakeholderstrategieën</li>
+                            <li>Resultaat: hogere betrokkenheid en teamperformance</li>
+                        </ul>
+                    </article>
+                </div>
+            </section>
+
+            <section class="section section--microlearning">
+                <div class="section__header">
+                    <h2>Recente microlearnings</h2>
+                    <p>Korte leertrajecten en certificaten die inspelen op actuele ontwikkelingen.</p>
+                </div>
+                <div class="training-timeline">
+                    <div class="timeline-item">
+                        <span class="timeline-item__date">Jan 2024</span>
+                        <div class="timeline-item__content">
+                            <h3>Power BI Advanced Analytics</h3>
+                            <p>
+                                Verdieping in DAX, dataflows en het automatiseren van KPI-rapportages voor het
+                                MT.
+                            </p>
+                        </div>
+                    </div>
+                    <div class="timeline-item">
+                        <span class="timeline-item__date">Okt 2023</span>
+                        <div class="timeline-item__content">
+                            <h3>ESG Reporting in Supply Chains</h3>
+                            <p>
+                                Microlearning rond CSRD-vereisten, emissieberekeningen en het rapporteren van
+                                duurzame prestaties.
+                            </p>
+                        </div>
+                    </div>
+                    <div class="timeline-item">
+                        <span class="timeline-item__date">Mei 2023</span>
+                        <div class="timeline-item__content">
+                            <h3>Negotiation Skills for Logistics</h3>
+                            <p>
+                                Training in scenario-based onderhandelingen en het opstellen van service level
+                                agreements.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="section section--cta">
+                <div class="section__header">
+                    <h2>Klaar voor de volgende stap?</h2>
+                    <p>
+                        Ik combineer praktijkervaring met actuele kennis. Laten we bespreken hoe mijn expertise
+                        jouw organisatie kan versterken.
+                    </p>
+                    <a class="button" href="contact.html">Plan een kennismaking</a>
+                </div>
+            </section>
+        </main>
+
+        <footer class="footer">
+            <p>&copy; <span id="year"></span> Sara de Vries. Alle rechten voorbehouden.</p>
+            <a class="back-to-top" href="#top">Terug naar boven &uarr;</a>
+        </footer>
+    </div>
+
+    <script>
+        document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated trainings page outlining major programmes, microlearnings, and a call-to-action
- extend the shared stylesheet with training-specific layouts for cards and a timeline
- link to the trainings page from the portfolio hero contact area

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68dcce39303883248771676c9b56bbe5